### PR TITLE
Fix role compatibility with ansible-core 2.19 by replacing deprecated git_config usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This role provide a compliance for install git-lfs on your target host.
 
 This role was developed using Ansible 2.5 Backwards compatibility is not guaranteed.
 Use `ansible-galaxy install diodonfrost.git_lfs` to install the role on your system.
-*   Ansible >= 2.8
-*   Python >= 2.7
+
+* Ansible >= 2.11
+* Python >= 2.7
 
 Supported platforms:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,10 +2,10 @@ galaxy_info:
   role_name: git_lfs
   author: diodonfrost
   company: diodonfrost
-  description:  Ansible role for install git lfs
+  description: Ansible role for install git lfs
   license: license Apache
 
-  min_ansible_version: 2.8
+  min_ansible_version: 2.16
 
   platforms:
     - name: EL
@@ -68,3 +68,6 @@ galaxy_info:
     - development
 
 dependencies: []
+
+collections:
+  - community.general

--- a/tasks/setup-Linux.yml
+++ b/tasks/setup-Linux.yml
@@ -65,8 +65,7 @@
     state: present
 
 - name: Linux | Check Git LFS initialization
-  git_config:
-    list_all: true
+  community.general.git_config_info:
     scope: global
   register: git_global_config
 


### PR DESCRIPTION
Fixes compatibility with ansible-core 2.19 / Ansible 12 by replacing the deprecated git_config task (list_all: true) with community.general.git_config_info module.

Resolves: https://github.com/diodonfrost/ansible-role-git-lfs/issues/3