### PR TITLE
Fix: deprecated usage of git_config (ansible-core 2.19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This role provide a compliance for install git-lfs on your target host.
 
 This role was developed using Ansible 2.5 Backwards compatibility is not guaranteed.
 Use `ansible-galaxy install diodonfrost.git_lfs` to install the role on your system.
-*   Ansible >= 2.8
-*   Python >= 2.7
+* Ansible >= 2.11
+* Python >= 2.7
 
 Supported platforms:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,10 +2,10 @@ galaxy_info:
   role_name: git_lfs
   author: diodonfrost
   company: diodonfrost
-  description:  Ansible role for install git lfs
+  description: Ansible role for installing git lfs
   license: license Apache
 
-  min_ansible_version: 2.8
+  min_ansible_version: 2.16
 
   platforms:
     - name: EL
@@ -68,3 +68,6 @@ galaxy_info:
     - development
 
 dependencies: []
+
+collections:
+  - community.general

--- a/tasks/setup-Darwin.yml
+++ b/tasks/setup-Darwin.yml
@@ -6,8 +6,7 @@
     state: present
 
 - name: Darwin | Check Git LFS initialization
-  git_config:
-    list_all: true
+  community.general.git_config_info:
     scope: global
   register: git_global_config
 

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -5,8 +5,7 @@
     state: present
 
 - name: FreeBSD | Check Git LFS initialization
-  git_config:
-    list_all: true
+  community.general.git_config_info:
     scope: global
   register: git_global_config
 

--- a/tasks/setup-Linux.yml
+++ b/tasks/setup-Linux.yml
@@ -65,8 +65,7 @@
     state: present
 
 - name: Linux | Check Git LFS initialization
-  git_config:
-    list_all: true
+  community.general.git_config_info:
     scope: global
   register: git_global_config
 

--- a/tasks/setup-OpenBSD.yml
+++ b/tasks/setup-OpenBSD.yml
@@ -5,8 +5,7 @@
     state: present
 
 - name: OpenBSD | Check Git LFS initialization
-  git_config:
-    list_all: true
+  community.general.git_config_info:
     scope: global
   register: git_global_config
 


### PR DESCRIPTION
Same as #4, but fixing all platforms.

Until a fix is merged (or someone maintains a proper fork), something like this works in `requirements.yml`:
```yml
---
roles:
  - name: diodonfrost.git_lfs
    src: git+https://github.com/marcusfreisleben/ansible-role-git-lfs.git
    version: 9c8c129d4cb641bade3afeeb93ccab332a3f0398
```